### PR TITLE
Bump to Rust 2024 edition

### DIFF
--- a/bitfield/Cargo.toml
+++ b/bitfield/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitfield"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "macros"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 proc-macro = true

--- a/replicator/Cargo.toml
+++ b/replicator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "replicator"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [features]
 utils = ["dep:piper"]

--- a/replicator/src/lib.rs
+++ b/replicator/src/lib.rs
@@ -9,7 +9,7 @@
 //! [`CoreMethods`].
 //!
 
-#![warn(missing_debug_implementations, rust_2024_compatibility)]
+#![warn(missing_debug_implementations)]
 #![deny(clippy::needless_pass_by_ref_mut)]
 
 #[cfg(test)]

--- a/replicator/src/test.rs
+++ b/replicator/src/test.rs
@@ -1,5 +1,4 @@
 #![allow(unused_variables)]
-#![allow(edition_2024_expr_fragment_specifier)]
 use std::time::Duration;
 
 use hypercore::{HypercoreBuilder, Storage};

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "utils"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 replicator = { path = "../replicator", features = ["utils"] }


### PR DESCRIPTION
This fixed some "tail expression temporary scope" warnings